### PR TITLE
Add a rectangle around the face in the FaceAI view

### DIFF
--- a/day1/Application/female-app-innovation-frontend/src/views/FaceAI.vue
+++ b/day1/Application/female-app-innovation-frontend/src/views/FaceAI.vue
@@ -1,10 +1,15 @@
 <template>
   <section>
+    <canvas id="ghostVideo" style="display: none"></canvas>
     <div v-if="!faces">
+      <div id="faceRectContainer">
+        <canvas id="faceRect"></canvas>
+      </div>
       <EasyCamera
         v-on:close="onClose"
         ref="camera"
         v-model="picture"
+        :fullscreenZIndex="-1"
         fullscreen
       ></EasyCamera>
     </div>
@@ -46,6 +51,9 @@ export default class FaceAI extends Vue {
 
   picture = "";
   faces: any = null;
+  liveFaces: any = null;
+  faceRect = { width: 92, height: 92, left: 301, top: 149 }; // hardcoded rectangle for testing
+  useLiveFaceDetection = true; // toggle live face detection in camera view
 
   columns = [
     { field: "age", label: "Age" },
@@ -58,6 +66,100 @@ export default class FaceAI extends Vue {
 
   onClose() {
     router.back();
+  }
+
+  created() {
+    window.setInterval(() => {
+      let canvas = document.getElementById("ghostVideo") as HTMLCanvasElement; // declare a canvas element in your html
+      let ctx = canvas.getContext("2d");
+      let video = document.querySelector("video");
+      let imageWidth = 0;
+      let imageHeight = 0;
+
+      // move content of video tag into invisible canvas
+      const v = video;
+      if (ctx == null || v == null) return;
+
+      try {
+        imageWidth = v.videoWidth;
+        imageHeight = v.videoHeight;
+        canvas.width = imageWidth;
+        canvas.height = imageHeight;
+        ctx.fillRect(0, 0, imageWidth, imageHeight);
+        ctx.drawImage(v, 0, 0, imageWidth, imageHeight);
+        const frame: string = canvas.toDataURL();
+        ctx.clearRect(0, 0, imageWidth, imageHeight); // clean the canvas
+
+        // need to use a new canvas here on top of the camera
+        const faceRectCanvas = document.getElementById(
+          "faceRect"
+        ) as HTMLCanvasElement;
+        faceRectCanvas.width = imageWidth;
+        faceRectCanvas.height = imageHeight;
+        var ctx2 = faceRectCanvas.getContext("2d");
+
+        // draw rectangle
+        if (ctx2 != null) {
+          ctx2.rect(
+            this.faceRect.left,
+            this.faceRect.top,
+            this.faceRect.width,
+            this.faceRect.height
+          );
+          ctx2.stroke();
+        }
+
+        if (frame !== "data:," && this.useLiveFaceDetection) {
+          // check if camera is ready
+          fetch(frame)
+            .then((res) => res.blob())
+            .then((blob) => {
+              client.face
+                .detectWithStream(blob, {
+                  returnFaceAttributes: [
+                    "age",
+                    "emotion",
+                    "facialHair",
+                    "smile",
+                    "gender",
+                    "glasses",
+                  ],
+                })
+                .then((response) => {
+                  this.liveFaces = response.map((face) => {
+                    const {
+                      age = 0,
+                      emotion: {
+                        anger = 0,
+                        contempt = 0,
+                        disgust = 0,
+                        fear = 0,
+                        happiness = 0,
+                        neutral = 0,
+                        sadness = 0,
+                        surprise = 0,
+                      } = {},
+                      facialHair: {
+                        moustache = 0,
+                        beard = 0,
+                        sideburns = 0,
+                      } = {},
+                      gender = "",
+                      smile = 0,
+                      glasses = "",
+                    } = { ...face.faceAttributes };
+
+                    console.log(face.faceRectangle);
+
+                    this.faceRect = face.faceRectangle;
+                  });
+                });
+            });
+        }
+      } catch (e) {
+        console.log(e);
+      }
+    }, 1000);
   }
 
   @Watch("picture")
@@ -124,4 +226,21 @@ export default class FaceAI extends Vue {
 }
 </script>
 
-<style scoped></style>
+<style scoped>
+#faceRectContainer {
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  margin-top: -3.25rem;
+}
+
+#faceRect {
+  object-fit: cover;
+  height: 100%;
+  width: 100%;
+  z-index: 2;
+}
+</style>

--- a/day1/Application/female-app-innovation-frontend/src/views/FaceAI.vue
+++ b/day1/Application/female-app-innovation-frontend/src/views/FaceAI.vue
@@ -50,11 +50,11 @@ export default class FaceAI extends Vue {
   @Ref() readonly camera!: any;
 
   picture = "";
-  faceInterval : number = null;
-  faces: any = [];
-  liveFaces: any = null;
+  faceInterval = -1;
+  faces: any[] = [];
+  liveFaces: any[] = [];
   faceRect = { width: 92, height: 92, left: 301, top: 149 }; // hardcoded rectangle for testing
-  useLiveFaceDetection = true; // toggle live face detection in camera view
+  useLiveFaceDetection = false; // toggle live face detection in camera view
 
   columns = [
     { field: "age", label: "Age" },
@@ -65,12 +65,12 @@ export default class FaceAI extends Vue {
     { field: "glasses", label: "Glasses" },
   ];
 
-  onClose() {
+  onClose(): void {
     window.clearInterval(this.faceInterval);
     router.back();
   }
 
-  created() {
+  created(): void {
     this.faceInterval = window.setInterval(() => {
       let canvas = document.getElementById("ghostVideo") as HTMLCanvasElement; // declare a canvas element in your html
       let ctx = canvas.getContext("2d");
@@ -116,13 +116,11 @@ export default class FaceAI extends Vue {
           fetch(frame)
             .then((res) => res.blob())
             .then((blob) => {
-              client.face
-                .detectWithStream(blob)
-                .then((response) => {
-                  this.liveFaces = response.map((face) => {
-                    this.faceRect = face.faceRectangle;
-                  });
+              client.face.detectWithStream(blob).then((response) => {
+                this.liveFaces = response.map((face) => {
+                  this.faceRect = face.faceRectangle;
                 });
+              });
             });
         }
       } catch (e) {
@@ -132,7 +130,7 @@ export default class FaceAI extends Vue {
   }
 
   @Watch("picture")
-  savePicture() {
+  savePicture(): void {
     this.camera.stop();
     clearInterval(this.faceInterval);
     fetch(this.picture)
@@ -216,8 +214,7 @@ export default class FaceAI extends Vue {
 }
 </style>
 <style>
-
-body.has-navbar-fixed-bottom{
+body.has-navbar-fixed-bottom {
   padding-bottom: 0rem;
   padding-top: 0rem;
 }

--- a/day1/Application/female-app-innovation-frontend/src/views/FaceAI.vue
+++ b/day1/Application/female-app-innovation-frontend/src/views/FaceAI.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
-    <canvas id="ghostVideo" style="display: none"></canvas>
-    <div v-if="!faces">
+    <div v-if="faces.length == 0">
+      <canvas id="ghostVideo" style="display: none"></canvas>
       <div id="faceRectContainer">
         <canvas id="faceRect"></canvas>
       </div>
@@ -13,7 +13,7 @@
         fullscreen
       ></EasyCamera>
     </div>
-    <section v-if="faces">
+    <section v-if="faces.length > 0">
       <NavBarBack />
       <b-tabs>
         <b-tab-item label="Results">
@@ -50,10 +50,10 @@ export default class FaceAI extends Vue {
   @Ref() readonly camera!: any;
 
   picture = "";
-  faces: any = null;
+  faces: any = [];
   liveFaces: any = null;
   faceRect = { width: 92, height: 92, left: 301, top: 149 }; // hardcoded rectangle for testing
-  useLiveFaceDetection = true; // toggle live face detection in camera view
+  useLiveFaceDetection = false; // toggle live face detection in camera view
 
   columns = [
     { field: "age", label: "Age" },
@@ -235,6 +235,7 @@ export default class FaceAI extends Vue {
   left: 0;
   height: 100vh;
   margin-top: -3.25rem;
+  pointer-events: none;
 }
 
 #faceRect {
@@ -242,5 +243,12 @@ export default class FaceAI extends Vue {
   height: 100%;
   width: 100%;
   z-index: 2;
+}
+</style>
+<style>
+
+body.has-navbar-fixed-bottom{
+  padding-bottom: 0rem;
+  padding-top: 0rem;
 }
 </style>

--- a/day1/Application/female-app-innovation-frontend/src/views/FaceAI.vue
+++ b/day1/Application/female-app-innovation-frontend/src/views/FaceAI.vue
@@ -54,7 +54,8 @@ export default class FaceAI extends Vue {
   faces: any[] = [];
   liveFaces: any[] = [];
   faceRect = { width: 92, height: 92, left: 301, top: 149 }; // hardcoded rectangle for testing
-  useLiveFaceDetection = false; // toggle live face detection in camera view
+  useLiveFaceDetection = true; // toggle live face detection in camera view
+  liveFaceDetectionInverval = 3000;
 
   columns = [
     { field: "age", label: "Age" },
@@ -126,7 +127,7 @@ export default class FaceAI extends Vue {
       } catch (e) {
         console.log(e);
       }
-    }, 2000);
+    }, this.liveFaceDetectionInverval);
   }
 
   @Watch("picture")

--- a/day1/Application/female-app-innovation-frontend/src/views/Microphone.vue
+++ b/day1/Application/female-app-innovation-frontend/src/views/Microphone.vue
@@ -48,4 +48,8 @@ export default class Microphone extends Vue {
 }
 </script>
 
-<style scoped></style>
+<style scoped>
+#microphone{
+  margin-top: 3.25rem;
+}
+</style>

--- a/day1/Application/female-app-innovation-frontend/src/views/Microphone.vue
+++ b/day1/Application/female-app-innovation-frontend/src/views/Microphone.vue
@@ -30,7 +30,7 @@ var recognizer: SpeechRecognizer;
 export default class Microphone extends Vue {
   text = "";
 
-  onStream(stream: MediaStream) {
+  onStream(stream: MediaStream): void {
     const audioConfig = AudioConfig.fromStreamInput(stream);
     recognizer = new SpeechRecognizer(speechConfig, audioConfig);
     recognizer.recognizing = this.onRegonitionResult;
@@ -38,18 +38,18 @@ export default class Microphone extends Vue {
     recognizer.startContinuousRecognitionAsync();
   }
 
-  onRegonitionResult(sender: any, event: SpeechRecognitionEventArgs) {
+  onRegonitionResult(sender: any, event: SpeechRecognitionEventArgs): void {
     this.text = event.result.text;
   }
 
-  onResult() {
+  onResult(): void {
     recognizer.stopContinuousRecognitionAsync();
   }
 }
 </script>
 
 <style scoped>
-#microphone{
+#microphone {
   margin-top: 3.25rem;
 }
 </style>


### PR DESCRIPTION
This PR adds "live" face detection to the camera view.
In the FaceAI view, every second a request is sent to the FaceAPI to detect a face in the image. This might be problematic when the view is open for longer because this request is limited to 20 requests per minute according to the docs.
The feature is enabled by default but can be disabled (for testing) by setting `useLiveFaceDetection` to `false`. In that case, a hardcoded rectangle will be drawn.

- [x] Draw a rectangle on the face when detected
- [x] Cleanup request code
- [x] Clear interval
- [x] Fix linter
- [x] Fix navigation (currently one canvas overlays the camera UI)